### PR TITLE
remove extra supported icon name from readme list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ _NOTE_: each Icon package has it's own subfolder under `react-icons` you import 
 
 ### Linea Basic Icons
 
-### Feather Icons
-
 You can add more icons by submitting pull requests or creating issues.
 
 | key       | default   | memo                         |


### PR DESCRIPTION
There was an extra supported library name in readme "Feather Icon" which is currently not supported by this library. I've removed it in this PR.